### PR TITLE
HCK-6979: Default type should be varchar(20)

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -276,7 +276,6 @@ making sure that you maintain a proper JSON format.
 				"minValue": 1,
 				"maxValue": 128,
 				"step": 1,
-				"defaultValue": 1,
 				"typeDecorator": true,
 				"dependency": {
 					"type": "and",

--- a/types/array.json
+++ b/types/array.json
@@ -24,10 +24,10 @@
 	"subtypes": {
 		"array": {
 			"childValueType": [
+				"char",
 				"array",
 				"binary",
 				"boolean",
-				"char",
 				"datetime",
 				"json",
 				"multiset",

--- a/types/char.json
+++ b/types/char.json
@@ -29,8 +29,8 @@
 		"enum": [],
 		"sample": "",
 		"comments": "",
-		"mode": "char",
-		"length": 1
+		"mode": "varchar",
+		"length": 20
 	},
 	"subtypes": {
 		"object": {

--- a/types/object.json
+++ b/types/object.json
@@ -10,10 +10,10 @@
 	"subtypes": {
 		"object": {
 			"childValueType": [
+				"char",
 				"array",
 				"binary",
 				"boolean",
-				"char",
 				"datetime",
 				"json",
 				"multiset",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-6979" title="HCK-6979" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-6979</a>  [PROD][DB2] Default type for attribute and array item should be varchar(20)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

`childValueType` affects what type is used for the newly created item. And somehow "defaultValue" in the field config blocks length=20 from to be set, removed.