### PR TITLE
Add default name for view in Db2 so that it complies with rules (no s…

### DIFF
--- a/properties_pane/defaultData.json
+++ b/properties_pane/defaultData.json
@@ -33,6 +33,7 @@
 	},
 	"user": {},
 	"view": {
+		"name": "new_view",
 		"viewOn": "",
 		"pipeline": ""
 	},


### PR DESCRIPTION
HCK-7981: add default name view "new_view" in Db2 so that it's compliant with naming rules (no space allowed)