### PR TITLE
HCK-7990: Fix splitting of column statements when deactivating the last one

### DIFF
--- a/constants/constants.js
+++ b/constants/constants.js
@@ -11,7 +11,10 @@ const TABLE_TYPE = {
 	view: 'VIEW',
 };
 
+const INLINE_COMMENT = '--';
+
 module.exports = {
 	ERROR_MESSAGE,
 	TABLE_TYPE,
+	INLINE_COMMENT,
 };

--- a/forward_engineering/ddlProvider/ddlHelpers/table/getTableProps.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/table/getTableProps.js
@@ -96,7 +96,6 @@ const getDividedForeignKeyConstraints = ({ foreignKeyConstraints }) => {
 
 /**
  * @param {{
- * app: { require: (moduleName: string) => any; }
  * columns: string[],
  * foreignKeyConstraints: object[],
  * keyConstraints: object[],

--- a/forward_engineering/ddlProvider/ddlHelpers/table/getTableProps.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/table/getTableProps.js
@@ -8,6 +8,7 @@ const {
 	divideIntoActivatedAndDeactivated,
 } = require('../../../utils/general');
 const { getOptionsString } = require('../constraint/getOptionsString');
+const { joinActivatedAndDeactivatedColumnStatements } = require('../../../utils/joinActivatedAndDeactivatedStatements');
 const { INLINE_COMMENT } = require('../../../../constants/constants');
 
 /**
@@ -104,9 +105,7 @@ const getDividedForeignKeyConstraints = ({ foreignKeyConstraints }) => {
  *
  * @returns {string}
  */
-const getTableProps = ({ app, columns, foreignKeyConstraints, keyConstraints, checkConstraints, isActivated }) => {
-	const { joinActivatedAndDeactivatedStatements } = app.require('@hackolade/ddl-fe-utils');
-
+const getTableProps = ({ columns, foreignKeyConstraints, keyConstraints, checkConstraints, isActivated }) => {
 	const dividedKeysConstraints = getDividedKeysConstraints({ keyConstraints, isActivated });
 	const dividedForeignKeyConstraints = getDividedForeignKeyConstraints({ foreignKeyConstraints });
 	const keyConstraintsString = generateConstraintsString({
@@ -121,17 +120,7 @@ const getTableProps = ({ app, columns, foreignKeyConstraints, keyConstraints, ch
 		dividedConstraints: { activatedItems: checkConstraints, deactivatedItems: [] },
 		isParentActivated: isActivated,
 	});
-	const columnStatementDtos = columns.map(column => {
-		return {
-			statement: column,
-			isActivated: !column.startsWith(INLINE_COMMENT),
-		};
-	});
-	const columnsString = joinActivatedAndDeactivatedStatements({
-		statementDtos: columnStatementDtos,
-		delimiter: ',',
-		indent: '\n\t',
-	});
+	const columnsString = joinActivatedAndDeactivatedColumnStatements({ columns });
 	const tableProps = assignTemplates({
 		template: templates.createTableProps,
 		templateData: {

--- a/forward_engineering/ddlProvider/ddlHelpers/table/getTableProps.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/table/getTableProps.js
@@ -8,7 +8,7 @@ const {
 	divideIntoActivatedAndDeactivated,
 } = require('../../../utils/general');
 const { getOptionsString } = require('../constraint/getOptionsString');
-const { joinActivatedAndDeactivatedColumnStatements } = require('../../../utils/joinActivatedAndDeactivatedStatements');
+const { joinActivatedAndDeactivatedStatements } = require('../../../utils/joinActivatedAndDeactivatedStatements');
 const { INLINE_COMMENT } = require('../../../../constants/constants');
 
 /**
@@ -119,7 +119,8 @@ const getTableProps = ({ columns, foreignKeyConstraints, keyConstraints, checkCo
 		dividedConstraints: { activatedItems: checkConstraints, deactivatedItems: [] },
 		isParentActivated: isActivated,
 	});
-	const columnsString = joinActivatedAndDeactivatedColumnStatements({ columns });
+	const columnsString = joinActivatedAndDeactivatedStatements({ statements: columns, indent: '\n\t' });
+
 	const tableProps = assignTemplates({
 		template: templates.createTableProps,
 		templateData: {

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -37,16 +37,12 @@ const { joinActivatedAndDeactivatedStatements } = require('../utils/joinActivate
  * @returns {string}
  */
 const getViewColumnsAsString = ({ columns }) => {
-	const statementDtos = columns.map(({ statement, isActivated }) => {
-		return {
-			statement: commentIfDeactivated(statement, { isActivated, isPartOfLine: false }),
-			isActivated,
-		};
-	});
 	const indent = '\n\t\t';
-	const statements = joinActivatedAndDeactivatedStatements({ statementDtos, delimiter: ',', indent });
+	const statements = columns.map(({ statement, isActivated }) => {
+		return commentIfDeactivated(statement, { isActivated, isPartOfLine: false });
+	});
 
-	return indent + statements;
+	return indent + joinActivatedAndDeactivatedStatements({ statements, delimiter: ',', indent });
 };
 
 module.exports = (baseProvider, options, app) => {

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -360,6 +360,7 @@ module.exports = (baseProvider, options, app) => {
 			}
 
 			const tableProps = getTableProps({
+				app,
 				columns,
 				foreignKeyConstraints,
 				keyConstraints,

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -30,14 +30,13 @@ const { getIndexOptions } = require('./ddlHelpers/index/getIndexOptions.js');
 const { getTableType } = require('./ddlHelpers/table/getTableType.js');
 const { getName } = require('./ddlHelpers/jsonSchema/jsonSchemaHelper.js');
 const { hydrateAuxiliaryTableData } = require('./ddlHelpers/table/hydrateAuxiliaryTableData.js');
+const { joinActivatedAndDeactivatedStatements } = require('../utils/joinActivatedAndDeactivatedStatements');
 
 /**
  * @param {{ columns: object[] }}
  * @returns {string}
  */
-const getViewColumnsAsString = ({ app, columns }) => {
-	const { joinActivatedAndDeactivatedStatements } = app.require('@hackolade/ddl-fe-utils');
-
+const getViewColumnsAsString = ({ columns }) => {
 	const statementDtos = columns.map(({ statement, isActivated }) => {
 		return {
 			statement: commentIfDeactivated(statement, { isActivated, isPartOfLine: false }),
@@ -352,7 +351,6 @@ module.exports = (baseProvider, options, app) => {
 			}
 
 			const tableProps = getTableProps({
-				app,
 				columns,
 				foreignKeyConstraints,
 				keyConstraints,
@@ -438,7 +436,7 @@ module.exports = (baseProvider, options, app) => {
 			const orReplace = viewData.orReplace ? ' OR REPLACE' : '';
 
 			const { columns, tables } = getViewData({ keys: viewData.keys });
-			const columnsAsString = getViewColumnsAsString({ app, columns });
+			const columnsAsString = getViewColumnsAsString({ columns });
 			const commentStatement = getTableCommentStatement({
 				tableName: viewName,
 				description: viewData.description,

--- a/forward_engineering/utils/general.js
+++ b/forward_engineering/utils/general.js
@@ -1,4 +1,5 @@
 const { toLower } = require('lodash');
+const { INLINE_COMMENT } = require('../../constants/constants');
 
 /**
  * @param {{ text: string, tab: string }}
@@ -53,7 +54,7 @@ const divideIntoActivatedAndDeactivated = ({ items, mapFunction }) => {
  * @param {{ isActivated: boolean, isPartOfLine: boolean, inlineComment: string }}
  * @returns {string}
  */
-const commentIfDeactivated = (statement, { isActivated, isPartOfLine, inlineComment = '--' }) => {
+const commentIfDeactivated = (statement, { isActivated, isPartOfLine, inlineComment = INLINE_COMMENT }) => {
 	if (isActivated !== false) {
 		return statement;
 	}

--- a/forward_engineering/utils/joinActivatedAndDeactivatedStatements.js
+++ b/forward_engineering/utils/joinActivatedAndDeactivatedStatements.js
@@ -13,8 +13,12 @@ const getDelimiter = ({ index, numberOfStatements, lastIndexOfActivatedStatement
 	const isLastStatement = index === numberOfStatements - 1;
 	const isLastActivatedStatement = index === lastIndexOfActivatedStatement;
 
-	if (isLastStatement || isLastActivatedStatement) {
+	if (isLastStatement) {
 		return '';
+	}
+
+	if (isLastActivatedStatement) {
+		return ' --' + delimiter;
 	}
 
 	return delimiter;

--- a/forward_engineering/utils/joinActivatedAndDeactivatedStatements.js
+++ b/forward_engineering/utils/joinActivatedAndDeactivatedStatements.js
@@ -1,10 +1,6 @@
 const { INLINE_COMMENT } = require('../../constants/constants');
 
 /**
- * @typedef {{ statement: string; isActivated: boolean; }} StatementDto
- */
-
-/**
  * @param {{
  * index: number;
  * numberOfStatements: number;
@@ -26,18 +22,18 @@ const getDelimiter = ({ index, numberOfStatements, lastIndexOfActivatedStatement
 
 /**
  * @param {{
- * statementDtos: StatementDto[];
+ * statements: string[];
  * delimiter?: string;
  * indent?: string;
  * }}
  * @return {string}
  * */
-const joinActivatedAndDeactivatedStatements = ({ statementDtos, delimiter = ',', indent = '\n' }) => {
-	const lastIndexOfActivatedStatement = statementDtos.findLastIndex(({ isActivated }) => isActivated);
-	const numberOfStatements = statementDtos.length;
+const joinActivatedAndDeactivatedStatements = ({ statements, delimiter = ',', indent = '\n' }) => {
+	const lastIndexOfActivatedStatement = statements.findLastIndex(statement => !statement.startsWith(INLINE_COMMENT));
+	const numberOfStatements = statements.length;
 
-	return statementDtos
-		.map(({ statement }, index) => {
+	return statements
+		.map((statement, index) => {
 			const currentDelimiter = getDelimiter({
 				index,
 				numberOfStatements,
@@ -50,22 +46,6 @@ const joinActivatedAndDeactivatedStatements = ({ statementDtos, delimiter = ',',
 		.join(indent);
 };
 
-/**
- * @param {{ columns?: string[] }}
- * @returns {string}
- */
-const joinActivatedAndDeactivatedColumnStatements = ({ columns = [] }) => {
-	const statementDtos = columns.map(column => {
-		return {
-			statement: column,
-			isActivated: !column.startsWith(INLINE_COMMENT),
-		};
-	});
-
-	return joinActivatedAndDeactivatedStatements({ statementDtos, delimiter: ',', indent: '\n\t' });
-};
-
 module.exports = {
 	joinActivatedAndDeactivatedStatements,
-	joinActivatedAndDeactivatedColumnStatements,
 };

--- a/forward_engineering/utils/joinActivatedAndDeactivatedStatements.js
+++ b/forward_engineering/utils/joinActivatedAndDeactivatedStatements.js
@@ -1,0 +1,71 @@
+const { INLINE_COMMENT } = require('../../constants/constants');
+
+/**
+ * @typedef {{ statement: string; isActivated: boolean; }} StatementDto
+ */
+
+/**
+ * @param {{
+ * index: number;
+ * numberOfStatements: number;
+ * lastIndexOfActivatedStatement: number;
+ * delimiter: string;
+ * }}
+ * @return {string}
+ * */
+const getDelimiter = ({ index, numberOfStatements, lastIndexOfActivatedStatement, delimiter }) => {
+	const isLastStatement = index === numberOfStatements - 1;
+	const isLastActivatedStatement = index === lastIndexOfActivatedStatement;
+
+	if (isLastStatement || isLastActivatedStatement) {
+		return '';
+	}
+
+	return delimiter;
+};
+
+/**
+ * @param {{
+ * statementDtos: StatementDto[];
+ * delimiter?: string;
+ * indent?: string;
+ * }}
+ * @return {string}
+ * */
+const joinActivatedAndDeactivatedStatements = ({ statementDtos, delimiter = ',', indent = '\n' }) => {
+	const lastIndexOfActivatedStatement = statementDtos.findLastIndex(({ isActivated }) => isActivated);
+	const numberOfStatements = statementDtos.length;
+
+	return statementDtos
+		.map(({ statement }, index) => {
+			const currentDelimiter = getDelimiter({
+				index,
+				numberOfStatements,
+				lastIndexOfActivatedStatement,
+				delimiter,
+			});
+
+			return statement + currentDelimiter;
+		})
+		.join(indent);
+};
+
+/**
+ * @param {{ columns?: string[] }}
+ * @returns {string}
+ */
+const joinActivatedAndDeactivatedColumnStatements = ({ columns = [] }) => {
+	const statementDtos = columns.map(column => {
+		return {
+			statement: column,
+			isActivated: !column.startsWith(INLINE_COMMENT),
+		};
+	});
+
+	return joinActivatedAndDeactivatedStatements({ statementDtos, delimiter: ',', indent: '\n\t' });
+};
+
+module.exports = {
+	joinActivatedAndDeactivatedStatements,
+	joinActivatedAndDeactivatedColumnStatements,
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7990" title="HCK-7990" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-7990</a>  [DB2]: DDL script is not valid when the last attribute is commented in Table
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
