### PR TITLE
HCK-8151: use primary or unique constraint for relationship parent field

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,14 @@
                 "disablePipelines": true
             },
             "relationships": {
-                "compositeRelationships": true
+                "compositeRelationships": {
+                    "allowRelationshipsByProperties": [
+                        "primaryKey",
+                        "unique",
+                        "compositeUniqueKey",
+                        "compositePrimaryKey"
+                    ]
+                }
             },
             "FEScriptCommentsSupported": true,
             "enableFetchSystemEntitiesCheckbox": true,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8151" title="HCK-8151" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-8151</a>  Other SQL targets: Use Unique constraint of the parent field while creating relationship
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

A relationship parent field should be:

a PK or
a part of composite PK or
UK or
a part of composite PK