### PR TITLE
HCK-9128: Handle indexes without name in Db2

### DIFF
--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -386,7 +386,7 @@ module.exports = (baseProvider, options, app) => {
 		createIndex(tableName, index) {
 			const indexName = getIndexName({ index });
 
-			if (!indexName.trim() || !index.indxKey.length) {
+			if (!index.indxName || !index.indxKey.length) {
 				return '';
 			}
 

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -386,7 +386,7 @@ module.exports = (baseProvider, options, app) => {
 		createIndex(tableName, index) {
 			const indexName = getIndexName({ index });
 
-			if (!indexName.trim()) {
+			if (!indexName.trim() || !index.indxKey.length) {
 				return '';
 			}
 

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -385,6 +385,11 @@ module.exports = (baseProvider, options, app) => {
 
 		createIndex(tableName, index) {
 			const indexName = getIndexName({ index });
+
+			if (!indexName.trim()) {
+				return '';
+			}
+
 			const indexType = getIndexType({ index });
 			const indexOptions = getIndexOptions({ index });
 			const indexTableName = getNamePrefixedWithSchemaName({ name: tableName, schemaName: index.schemaName });

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -401,7 +401,10 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Name",
 						"propertyKeyword": "indxName",
 						"propertyTooltip": "",
-						"propertyType": "text"
+						"propertyType": "text",
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "Activated",

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -424,7 +424,11 @@ making sure that you maintain a proper JSON format.
 						"propertyKeyword": "indxKey",
 						"propertyType": "fieldList",
 						"template": "orderedList",
-						"attributeList": ["asc", "desc", "random"]
+						"attributeList": ["asc", "desc", "random"],
+						"validation": {
+							"minLength": 1,
+							"required": true
+						}
 					},
 					{
 						"propertyName": "Include keys",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9128" title="HCK-9128" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9128</a>  Handle indexes without name in all SQL-like targets, depending whether name is mandatory or not
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Updated validation of required fields in "Create Index" script
- index name is required
- columns are required