### PR TITLE
HCK-9173: comment out inactive schema statement in script

### DIFF
--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -64,10 +64,11 @@ module.exports = (baseProvider, options, app) => {
 				schemaName: containerData.name,
 				authorizationName: containerData.authorizationName,
 				dataCapture: containerData.dataCapture,
+				isActivated: containerData.isActivated,
 			};
 		},
 
-		createSchema({ schemaName, ifNotExist, authorizationName, dataCapture }) {
+		createSchema({ schemaName, ifNotExist, authorizationName, dataCapture, isActivated }) {
 			const schemaStatement = assignTemplates({
 				template: templates.createSchema,
 				templateData: {
@@ -77,7 +78,7 @@ module.exports = (baseProvider, options, app) => {
 				},
 			});
 
-			return schemaStatement;
+			return commentIfDeactivated(schemaStatement, { isActivated });
 		},
 
 		hydrateColumn({ columnDefinition, jsonSchema, schemaData, definitionJsonSchema = {} }) {

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -68,7 +68,7 @@ module.exports = (baseProvider, options, app) => {
 			};
 		},
 
-		createSchema({ schemaName, ifNotExist, authorizationName, dataCapture, isActivated }) {
+		createSchema({ schemaName, ifNotExist, authorizationName, dataCapture, isActivated = true }) {
 			const schemaStatement = assignTemplates({
 				template: templates.createSchema,
 				templateData: {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9173" title="HCK-9173" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9173</a>  Statements are still incorrectly present in DDL/Script tab after 'isActivated' is disabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

You have no Jira task for this PR? Describe your changes here...

...

## Technical details

You feel the need to provide technical explanations? You can do it here...

...