### PR TITLE
HCK-10528: updated conversion and derivment configs to handle nchar and char max length

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -45,6 +45,16 @@
 					"length": 32704
 				}
 			},
+			{
+				"from": {
+					"type": "varchar",
+					"mode": "char",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 255
+				}
+			},
             {
 				"from": {
 					"type": "nvarchar",
@@ -52,6 +62,16 @@
 				},
 				"to": {
 					"length": 32704
+				}
+			},
+			{
+				"from": {
+					"type": "nvarchar",
+					"mode": "nchar",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 255
 				}
 			},
             {

--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -62,7 +62,25 @@
 				"to": {
 					"hasMaxLength": true
 				}
-			}
+			},
+			{
+				"from": {
+					"mode": "char",
+					"length": 255
+				},
+				"to": {
+					"hasMaxLength": true
+				}
+			},
+			{
+				"from": {
+					"mode": "nchar",
+					"length": 255
+				},
+				"to": {
+					"hasMaxLength": true
+				}
+			},
 		]
 	}
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10528" title="HCK-10528" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10528</a>  [DB2] char/nchar datatypes with max length incorrect derived/converted from/to Poly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Updated conversion and derivment configs to handle nchar and char max length