### PR TITLE
fix: RE from instance

### DIFF
--- a/shared/helpers/queryHelper.js
+++ b/shared/helpers/queryHelper.js
@@ -77,7 +77,7 @@ const getTableNamesQuery = ({ tableType, includeSystemCollection }) => {
 const getGenerateTableDdlQuery = ({ schemaName, tableName, tableType }) => {
 	const tableArgument = tableType === TABLE_TYPE.table ? '-t' : '-v';
 
-	return `CALL SYSPROC.DB2LK_GENERATE_DDL('-a -e -z ""${schemaName}"" ${tableArgument} ""${tableName}""', ?);`;
+	return `CALL SYSPROC.DB2LK_GENERATE_DDL('-a -e -z "${schemaName}" ${tableArgument} "${tableName}"', ?);`;
 };
 
 /**


### PR DESCRIPTION
## Content

* removed redundant escape, not needed anymore after moving from cli args to stdin approach (related to https://hackolade.atlassian.net/browse/HCK-14316)

