### PR TITLE
HCK-14785: RE relationships

### DIFF
--- a/shared/helpers/instanceHelper.js
+++ b/shared/helpers/instanceHelper.js
@@ -91,7 +91,7 @@ const getTableDdl = async ({ connection, schemaName, tableName, objectType, logg
 
 		await connection.execute({ query: clearQuery, callable: true, inparam: opToken });
 
-		return ddlResult.map(row => queryHelper.ensureTerminator({ query: row.SQL_STMT })).join('\n');
+		return ddlResult.map(queryHelper.postProcessDdlStatement).join('\n');
 	} catch (error) {
 		logger.error(error);
 

--- a/shared/helpers/queryHelper.js
+++ b/shared/helpers/queryHelper.js
@@ -9,6 +9,15 @@ const cleanUpQuery = ({ query = '' }) => query.replaceAll(/\s+/g, ' ');
 const ensureTerminator = ({ query = '' }) => (query.trimEnd().endsWith(';') ? query : `${query};`);
 
 /**
+ * finds every quoted identifier and removes *only* trailing whitespace
+ * @param {{ query: string }} params
+ * @returns {string}
+ */
+const normalizeDb2Identifiers = ({ query = '' }) => {
+	return query.replaceAll(/"([^"]*)"/g, (_, name) => `"${name.trimEnd()}"`);
+};
+
+/**
  * @param {{ query: string, schemaNameKeyword: string }} params
  * @returns {string}
  */
@@ -109,6 +118,16 @@ const getClearTableDdlQuery = () => {
 	return 'CALL SYSPROC.DB2LK_CLEAN_TABLE(?);';
 };
 
+/**
+ * @param {{ SQL_STMT: string}} row - select query ddl result
+ * @returns {string}
+ */
+const postProcessDdlStatement = row => {
+	let statement = queryHelper.ensureTerminator({ query: row.SQL_STMT });
+	statement = queryHelper.normalizeDb2Identifiers({ query: statement });
+	return statement;
+};
+
 const queryHelper = {
 	cleanUpQuery,
 	getDbVersionQuery,
@@ -119,6 +138,8 @@ const queryHelper = {
 	getSelectTableDdlQuery,
 	getClearTableDdlQuery,
 	ensureTerminator,
+	normalizeDb2Identifiers,
+	postProcessDdlStatement,
 };
 
 module.exports = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14785" title="HCK-14785" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-14785</a>  [DB2][RE from instance] relationships aren't REed from instance if schema name length is less than 8
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content:

* normalized schema names in DDL statements on RE.

## Technical details

* The PR fixes the behavior of `CALL SYSPROC.DB2LK_GENERATE_DDL`, where the schema names are right padded by default. For examples:
  * schema name in the model is `x`
  * after applying it to the instance, trying to reverse it back as DDL will return: 

```sql
-- "x"."t" definition

CREATE TABLE "x       "."t"  (
		  "c1" VARCHAR(20 OCTETS) )   
		 IN "IBMDB2SAMPLEREL"  
		 ORGANIZE BY ROW;
```

* This happens because the schema name was created as a fixed-length `CHAR` value (default `8`) and is blank-padded internally to full length.
* This impacts the internal resolution of references on most levels (relationships, types, columns, views, etc.)